### PR TITLE
Reduce size of the connection pool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,8 @@ logger.info(maskPassword("connecting to database " + dbUri, dbPassword!));
 
 unleash.start({
     databaseUrl: dbUri,
+    poolMin: 1,
+    poolMax: 3,
     port: 8080,
     secret: dbPassword,
     adminAuthentication: 'custom',


### PR DESCRIPTION
Unleash was using up 10 DB connections per pod (20 in total), but it only needs one per pod, really. This sets it to max 3 for a safety margin, with a total of 6 DB connections with 2 pods.