### PR TITLE
Cache IAP public keys for 30 minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 ![Workflow status](https://github.com/navikt/unleash/workflows/build/badge.svg?branch=unleash-v4)
 
-En enkel [Unleash v4 server][unleash] med Google IAP
-autentisering. Denne er bygget for å fungere godt sammen med [Unleasherator][unleasherator] vår Kubernetes operator for å håndtere Unleash instanser.
+Simple [Unleash v4 server][unleash] with [Google IAP authentication][google-iap]. Built to work well with [Unleasherator][unleasherator] our Kubernetes operator for managing Unleash instances.
 
 [unleash]: https://github.com/Unleash/unleash
 [unleasherator]: https://github.com/nais/unleasherator
@@ -32,32 +31,74 @@ sequenceDiagram
     Unleash->>User: response
 ```
 
-## Konfigurasjon
+## Configuration
 
 | Environment variable | Description | Default |
 |----------------------|-------------|---------|
 | `GOOGLE_IAP_JWT_HEADER` | Header name for JWT token from Google IAP | `x-goog-iap-jwt-assertion` |
 | `GOOGLE_IAP_JWT_ISSUER` | Issuer for JWT token from Google IAP | `https://cloud.google.com/iap` |
 | `GOOGLE_IAP_JWT_AUDIENCE` | Audience for JWT token from Google IAP | **REQUIRED** |
+| `IAP_PUBLIC_KEY_CACHE_TIME` | Cache time for JWT token public keys from Google IAP | `3600` |
 
 ### IAP JWT Audience
 
-`GOOGLE_IAP_JWT_AUDIENCE` skal være en string på følgende format:
+`GOOGLE_IAP_JWT_AUDIENCE` should be a string in the following format:
 
 ```text
 /projects/PROJECT_NUMBER/global/backendServices/SERVICE_ID
 ```
 
-## Oppsett for utvikling lokalt
+## Setup for local development
 
-For å teste kjøre opp en test-instans lokalt kan man bruke `docker-compose up --build`.
-Denne vil sette opp en lokal postgres database i en docker-container og
-eksponere unleash på url `http://localhost:8080`.
+### Prerequisites
 
-For å bygge koden kjører du `yarn build`. Dette vil kompilere typescript-filene til ES2017
-som legges i `./dist/`. Unleash kan da kjøres med `yarn start`.
+- [Node.js][nodejs] 16 or later
+- [Docker][docker]
 
-## Henvendelser
+[nodejs]: https://nodejs.org/en/
+[docker]: https://www.docker.com/
 
-Henvendelser og spørsmål kan gjøres via issues på repoet. For direkte kontakt kan man også høre med Tjenesteplattform (NADA og NAIS). For NAV-ansatte kan dette enklest gjøres via slack-kanalen #unleash. Der vil man også kunne komme i kontakt med enkelte av utviklerne av Unleash (upstream).
-For eksterne er det mulig å sende mail til Audun F. Strand (audun.fauchald.strand@nav.no).
+### Running Unleash
+
+The simplest way to run Unleash is to use `docker-compose`:
+
+```bash
+docker-compose up --build
+```
+
+This will start a local Postgres database in a Docker container and expose Unleash on `http://localhost:8080`.
+
+To build the code, run `yarn build`. This will compile the TypeScript files to ES2017 and place them in `./dist/`. Unleash can then be run with `yarn start`. For convenience you can also use the `yarn build-and-start` command.
+
+Running Unleash locally requires a database. The easiest way to get one is to use Docker:
+
+```bash
+docker-compose up -d postgres
+```
+
+This will start a local Postgres database in a Docker container. You can then connect to it using the following credentials:
+
+```bash
+export DATABASE_USERNAME=unleash
+export DATABASE_PASSWORD=unleash
+export DATABASE_NAME=unleash
+export DATABASE_HOST=localhost
+export DATABASE_SSL=false
+```
+
+You also need the following environment variables:
+
+```bash
+export INIT_ADMIN_API_TOKENS=*:*.unleash4all
+export GOOGLE_IAP_AUDIENCE=/projects/123/global/backendServices/123
+```
+
+## Contact
+
+Requests and questions can be made via issues on the repo. For NAV employees this can be done easiest via the slack channel [#unleash][nav-slack-unleash].
+
+[nav-slack-unleash]: https://nav-it.slack.com/archives/C9BPTSULS
+
+## License
+
+[MIT](LICENSE)

--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -1,0 +1,30 @@
+import Cache from "./cache";
+
+describe("Cache", () => {
+  afterEach(() => {
+    Cache.clear(); // Reset the cache between tests
+  });
+
+  it("should cache and retrieve a value", () => {
+    const value = { foo: "bar" };
+    Cache.set("key", value, 1000);
+
+    const cached = Cache.get("key");
+    expect(cached).toEqual(value);
+  });
+
+  it("should return undefined for an expired value", async () => {
+    const value = { foo: "bar" };
+    Cache.set("key", value, 10);
+
+    await new Promise((resolve) => setTimeout(resolve, 20)); // Wait for the value to expire
+
+    const cached = Cache.get("key");
+    expect(cached).toBeUndefined();
+  });
+
+  it("should return undefined for a non-existent value", () => {
+    const cached = Cache.get("key");
+    expect(cached).toBeUndefined();
+  });
+});

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,0 +1,29 @@
+interface CachedValue<T> {
+  value: T;
+  expirationTime: number;
+}
+
+class Cache {
+  private cache: { [key: string]: CachedValue<any> } = {};
+
+  get<T>(key: string): T | undefined {
+    const cached = this.cache[key] as CachedValue<T> | undefined;
+    if (cached && cached.expirationTime > Date.now()) {
+      return cached.value;
+    } else {
+      delete this.cache[key];
+      return undefined;
+    }
+  }
+
+  set<T>(key: string, value: T, expirationTimeMs: number): void {
+    const expirationTime = Date.now() + expirationTimeMs;
+    this.cache[key] = { value, expirationTime };
+  }
+
+  clear(): void {
+    this.cache = {};
+  }
+}
+
+export default new Cache();

--- a/src/google-iap.ts
+++ b/src/google-iap.ts
@@ -2,13 +2,38 @@ import { RoleName } from "unleash-server/dist/lib/types/model";
 import { Logger } from "log4js";
 import { OAuth2Client, LoginTicket } from "google-auth-library";
 import { IapPublicKeysResponse } from "google-auth-library/build/src/auth/oauth2client";
+import cache from "./cache";
 
 export const IAP_JWT_HEADER: string =
   process.env.GOOGLE_IAP_JWT_HEADER || "x-goog-iap-jwt-assertion";
 export const IAP_JWT_ISSUER: string =
   process.env.GOOGLE_IAP_JWT_ISSUER || "https://cloud.google.com/iap";
 export const IAP_AUDIENCE: string = process.env.GOOGLE_IAP_AUDIENCE || "";
+export const IAP_PUBLIC_KEY_CACHE_TIME: number = parseInt(
+  process.env.IAP_PUBLIC_KEY_CACHE_TIME || `${30 * 60 * 1000}` // 30 minutes in milliseconds
+);
 
+// This is a wrapper around the cache that adds a fetch function. This is
+// useful when you want to cache the result of an async function.
+async function getCachedValue<T>(
+  key: string,
+  fetchFn: () => Promise<T>,
+  expirationTimeMs: number
+): Promise<T> {
+  const cached = cache.get<T>(key);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const value = await fetchFn();
+  cache.set(key, value, expirationTimeMs);
+
+  return value;
+}
+
+// This is a factory function that returns a function that can be used as a
+// middleware in unleash. The factory function is needed to be able to
+// initialize the OAuth2Client with the correct audience.
 async function createIapAuthHandler(): Promise<
   (app: any, config: any, services: any) => void
 > {
@@ -24,20 +49,34 @@ async function createIapAuthHandler(): Promise<
 
     app.use(async (req: any, res: any, next: any) => {
       logger.info("Request headers: ", req.headers);
-      const iapJwt: string | undefined = req.get(IAP_JWT_HEADER);
+      const iapJwtHeader: string | undefined = req.get(IAP_JWT_HEADER);
 
-      if (!iapJwt) {
+      if (!iapJwtHeader) {
         return next();
       }
 
+      // Fetch the public keys from Google and cache them.
+      let iapPublicKeys: IapPublicKeysResponse;
       try {
-        // @TODO can we cache this to speed things up?
-        const iapPublicKeys: IapPublicKeysResponse =
-          await oAuth2Client.getIapPublicKeys();
+        iapPublicKeys = await getCachedValue(
+          "iapPublicKeys",
+          () => {
+            const keys = oAuth2Client.getIapPublicKeys();
+            logger.info("Fetched IAP public keys: ", keys);
+            return keys;
+          },
+          IAP_PUBLIC_KEY_CACHE_TIME
+        );
+      } catch (error) {
+        logger.error("Failed to fetch IAP public keys", error);
+        return next(new Error("Failed to fetch IAP public keys"));
+      }
 
+      // Verify the JWT token and log in the user.
+      try {
         const login: LoginTicket =
           await oAuth2Client.verifySignedJwtWithCertsAsync(
-            iapJwt,
+            iapJwtHeader,
             iapPublicKeys.pubkeys,
             [IAP_AUDIENCE as string],
             [IAP_JWT_ISSUER]
@@ -46,9 +85,11 @@ async function createIapAuthHandler(): Promise<
         const tokenPayload = login.getPayload();
 
         if (!tokenPayload || !tokenPayload.email) {
+          logger.info("No email in JWT tokenPayload", tokenPayload);
           throw new Error("No email in JWT tokenPayload");
         }
 
+        // Login the user in Unleash.
         req.user = await userService.loginUserSSO({
           email: tokenPayload.email,
           // name: tokenPayload.name,

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,5 +1,6 @@
 import { IUnleash } from "unleash-server";
 import naisleash from "./server";
+import Cache from "./cache";
 import request from "supertest";
 import { newSignedToken } from "./utils";
 import nock from "nock";
@@ -34,7 +35,8 @@ beforeAll(async () => {
 });
 
 afterEach(() => {
-  nock.cleanAll();
+  nock.cleanAll(); // clean up nock mocks
+  Cache.clear(); // clean up cache
 });
 
 afterAll(async () => {


### PR DESCRIPTION
Add caching so we don't have to look up IAP public keys all the time.

Alternatively we could catch the key lookup error and refresh the keys when needed. Ref. https://stackoverflow.com/questions/44828856/google-iap-public-keys-expiry