### PR TITLE
Introduce generic oauth2 jwt validation

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
-nodejs 20.9.0
+nodejs 20.19.2
+yarn 1.22.22

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ sequenceDiagram
 
 ## Configuration
 
-### Authentication
+### Google IAP Authentication
 
 | environment variable        | description                                          | default                        |
 | --------------------------- | ---------------------------------------------------- | ------------------------------ |
@@ -47,6 +47,16 @@ sequenceDiagram
 ```text
 /projects/PROJECT_NUMBER/global/backendServices/SERVICE_ID
 ```
+
+### OAUTH JWT Authentication
+
+| environment variable | description                         | default                              |
+| -------------------- | ----------------------------------- | ------------------------------------ |
+| `OAUTH_JWT_AUTH`     | Enable generic Oauth JWT validation | `false`                              |
+| `OAUTH_JWT_HEADER`   | Header name for JWT token           | `X-Wonderwall-Forward-Auth-Token`    |
+| `OAUTH_JWT_ISSUER`   | Issuer for JWT token                | `https://auth.nais.io`               |
+| `OAUTH_JWT_AUDIENCE` | Audience for JWT token              | **REQUIRED**                         |
+| `OAUTH_JWT_KEYSET`   | Keyset URL to fetch keyset from     | `https://auth.nais.io/oauth/v2/keys` |
 
 ### Authorization
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/auto-instrumentations-node": "^0.48.0",
     "google-auth-library": "^9.11.0",
+    "jose": "5.10.0",
     "jsonwebtoken": "^9.0.2",
     "log4js": "^6.9.1",
     "unleash-server": "5.12.8"

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { NaisTeams } from "./nais-teams";
 
 const TEAMS_API_URL: string = process.env.TEAMS_API_URL || "";
 const TEAMS_API_TOKEN: string = process.env.TEAMS_API_TOKEN || "";
+const OAUTH_JWT_AUTH: boolean = (process.env.OAUTH_JWT_AUTH ?? "false") == "true";
 const TEAMS_ALLOWED_TEAMS: string[] = (
   process.env.TEAMS_ALLOWED_TEAMS || ""
 ).split(",");
@@ -13,7 +14,7 @@ const teamsService = new NaisTeams(
   TEAMS_ALLOWED_TEAMS,
 );
 
-naisleash(true, teamsService)
+naisleash(true, teamsService, OAUTH_JWT_AUTH)
   .then((server) => {
     const port: number = server.app.get("port");
     const logger = server.config.getLogger("nais/index.js");

--- a/src/oauth-fa.ts
+++ b/src/oauth-fa.ts
@@ -1,0 +1,167 @@
+import { createRemoteJWKSet, jwtVerify } from "jose";
+import { Logger } from "log4js";
+import { TeamsService } from "nais-teams";
+import { RoleName } from "unleash-server/dist/lib/types/model";
+import cache from "./cache";
+
+// Need to use require because package.json doesn't have `type: module`
+
+/**
+ * The header name for the IAP JWT token.
+ * @type {string}
+ */
+export const OAUTH_JWT_HEADER: string =
+  process.env.OAUTH_JWT_HEADER || "X-Wonderwall-Forward-Auth-Token";
+
+/**
+ * The issuer of the IAP JWT token.
+ * @type {string}
+ */
+export const OAUTH_JWT_ISSUER: string =
+  process.env.OAUTH_JWT_ISSUER || "https://auth.nais.io";
+
+/**
+ * The URL to the OAuth JWT keyset.
+ * @type {string}
+ */
+export const OAUTH_JWT_KEYSET: string =
+  process.env.OAUTH_JWT_KEYSET || "https://auth.nais.io/oauth/v2/keys";
+
+/**
+ * The audience of the IAP JWT token.
+ * @type {string}
+ */
+export const OAUTH_JWT_AUDIENCE: string = process.env.OAUTH_JWT_AUDIENCE || "";
+
+/**
+ * The time in milliseconds to cache the user validation result.
+ * @type {number}
+ */
+export const API_USER_VALIDATION_CACHE_TIME: number = parseInt(
+  process.env.TEAMS_USER_VALIDATION_CACHE_TIME || `${30 * 60 * 1000}`, // 30 minutes in milliseconds
+);
+
+// This is a wrapper around the cache that adds a fetch function. This is
+// useful when you want to cache the result of an async function.
+async function getCachedValue<T>(
+  key: string,
+  fetchFn: () => Promise<T>,
+  expirationTimeMs: number,
+): Promise<T> {
+  const cached = cache.get<T>(key);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const value = await fetchFn();
+  cache.set(key, value, expirationTimeMs);
+
+  return value;
+}
+
+/**
+ * Creates an IAP authentication handler middleware for an Express app.
+ *
+ * This is a factory function that returns a function that can be used as a
+ * middleware in unleash. The factory function is needed to be able to
+ * initialize the OAuth2Client with the correct audience.
+ *
+ * @param {TeamsService} teamsServer - The TeamsService instance to use for authorization.
+ * @returns {(app: any, config: any, services: any) => void} - The middleware function to use with the app.
+ * @throws {Error} - If the OAUTH_AUDIENCE environment variable is not set.
+ */
+async function createJWTAuthHandler(
+  teamsServer: TeamsService,
+): Promise<(app: any, config: any, services: any) => void> {
+  if (OAUTH_JWT_AUDIENCE === "") {
+    throw new Error("OAUTH_JWT_AUDIENCE is not set");
+  }
+
+  const JWKS = createRemoteJWKSet(new URL(OAUTH_JWT_KEYSET));
+
+  return function jwtAuthHandler(app: any, config: any, services: any): void {
+    const logger: Logger = config.getLogger("nais/oauth-fa.js");
+    const { userService }: any = services;
+
+    app.use(async (req: any, res: any, next: any) => {
+      logger.debug("jwtAuthHandler: request headers: ", req.headers);
+      const iapJwtHeader: string | undefined = req.get(OAUTH_JWT_HEADER);
+
+      if (!iapJwtHeader) {
+        logger.debug("jwtAuthHandler: no JWT header found");
+        return next();
+      }
+
+      // Verify the JWT token and log in the user.
+      try {
+        const { payload: tokenPayload } = await jwtVerify(iapJwtHeader, JWKS, {
+          issuer: OAUTH_JWT_ISSUER,
+          audience: OAUTH_JWT_AUDIENCE,
+        });
+
+        // Check if the tokenPayload contains an email.
+        if (!tokenPayload || !tokenPayload.email) {
+          logger.error(
+            "jwtAuthHandler: no email in JWT tokenPayload",
+            tokenPayload,
+          );
+          throw new Error("No email in JWT tokenPayload");
+        }
+
+        const email = tokenPayload.email as string;
+
+        // Check if the user is authorized to access the application.
+        const { status: isAuthorized, user: userData } = await getCachedValue(
+          email,
+          () => {
+            return teamsServer.authorize(email);
+          },
+          API_USER_VALIDATION_CACHE_TIME,
+        );
+
+        if (!isAuthorized || !userData) {
+          if (userData) {
+            logger.warn(
+              "jwtAuthHandler: user is not authorized",
+              tokenPayload.email,
+              userData,
+            );
+          } else {
+            logger.warn(
+              "jwtAuthHandler: user is not authorized",
+              tokenPayload.email,
+            );
+          }
+          throw new Error("User is not authorized");
+        }
+
+        logger.info("jwtAuthHandler: logging in user: ", userData);
+        req.user = await userService.loginUserSSO({
+          email: userData.email,
+          name: userData.name,
+          rootRole: RoleName.ADMIN,
+          autoCreate: true,
+        });
+      } catch (error) {
+        logger.error(
+          "jwtAuthHandler: JWT token validation failed with error",
+          error,
+        );
+      }
+
+      next();
+    });
+
+    app.use("/api", (req: any, res: any, next: any) => {
+      logger.debug("apiHandler: request user: ", req.user);
+
+      if (req.user) {
+        return next();
+      } else {
+        return res.status(401).send("Unauthorized");
+      }
+    });
+  };
+}
+
+export default createJWTAuthHandler;

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,7 @@ import {
   IUnleashOptions,
 } from "unleash-server/dist/lib/types/option";
 import createIapAuthHandler from "./google-iap";
+import createJWTAuthHandler from "./oauth-fa";
 import { createConfig } from "unleash-server/dist/lib/create-config";
 import {
   parseEnvVarBoolean,
@@ -18,8 +19,16 @@ import { TeamsService } from "nais-teams";
 async function naisleash(
   start: boolean,
   teamsService: TeamsService,
+  useJWTAuth: boolean = false,
 ): Promise<IUnleash> {
-  const iapAuthHandler = await createIapAuthHandler(teamsService);
+	let createFunc : ((teamsServer: TeamsService) => Promise<(app: any, config: any, services: any) => void>) | undefined = undefined;
+	if(useJWTAuth) {
+		createFunc = createJWTAuthHandler
+	} else {
+		createFunc = createIapAuthHandler
+	}
+	
+  const iapAuthHandler = await createFunc(teamsService);
   const unleashOptions: IUnleashOptions = {
     authentication: {
       type: IAuthType.CUSTOM,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5352,6 +5352,11 @@ joi@^17.3.0:
     "@sideway/formula" "^3.0.1"
     "@sideway/pinpoint" "^2.0.0"
 
+jose@5.10.0:
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-5.10.0.tgz#c37346a099d6467c401351a9a0c2161e0f52c4be"
+  integrity sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==
+
 js-levenshtein@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"


### PR DESCRIPTION
To support new Nais Auth, we need to validate a generic jwt token instead of google iap.
This generic handler is opt in.