### PR TITLE
fix: include dist in pnpm deploy and add e2e tests on push to main

### DIFF
--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # ratchet:pnpm/action-setup@v6.0.9
         with:
-          version: latest
+          version: 11.20.0
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # ratchet:actions/setup-node@v6.4.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # ratchet:pnpm/action-setup@v6.0.9
         with:
-          version: latest
+          version: 11.20.0
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # ratchet:actions/setup-node@v6.4.0
         with:
@@ -82,7 +82,7 @@ jobs:
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # ratchet:pnpm/action-setup@v6.0.9
         with:
-          version: latest
+          version: 11.20.0
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # ratchet:actions/setup-node@v6.4.0
         with:
@@ -124,7 +124,7 @@ jobs:
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # ratchet:pnpm/action-setup@v6.0.9
         with:
-          version: latest
+          version: 11.20.0
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # ratchet:actions/setup-node@v6.4.0
         with:
@@ -138,6 +138,7 @@ jobs:
   # Build Docker images and run full e2e tests (PR and push to main)
   docker-e2e:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: [lint, detect-versions, test-shared, test-unleash]
     permissions:
       contents: read
@@ -238,6 +239,7 @@ jobs:
   # Push: Build, push, and sign all Docker images
   build-push-sign:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: [lint, detect-versions, test-shared, test-unleash, docker-e2e]
     if: github.event_name == 'push'
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -135,11 +135,10 @@ jobs:
       - run: pnpm -r build
       - run: pnpm --filter unleash-${{ matrix.version }} test
 
-  # PR: Build Docker images and run full e2e tests
-  docker-e2e-pr:
+  # Build Docker images and run full e2e tests (PR and push to main)
+  docker-e2e:
     runs-on: ubuntu-latest
     needs: [lint, detect-versions, test-shared, test-unleash]
-    if: github.event_name == 'pull_request'
     permissions:
       contents: read
     strategy:
@@ -239,7 +238,7 @@ jobs:
   # Push: Build, push, and sign all Docker images
   build-push-sign:
     runs-on: ubuntu-latest
-    needs: [lint, detect-versions, test-shared, test-unleash]
+    needs: [lint, detect-versions, test-shared, test-unleash, docker-e2e]
     if: github.event_name == 'push'
     strategy:
       matrix:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ FROM node:24-alpine AS builder
 # Version argument - defaults to v5, can be overridden for v6, v7, etc.
 ARG UNLEASH_VERSION=v5
 
-# Install pnpm globally
-RUN npm install -g pnpm@latest
+# Keep builds reproducible across pull requests and releases.
+RUN npm install -g pnpm@11.20.0
 
 WORKDIR /workspace
 
@@ -30,9 +30,12 @@ COPY packages/unleash-${UNLEASH_VERSION} ./packages/unleash-${UNLEASH_VERSION}
 RUN pnpm --filter @nais/unleash-shared build && \
     pnpm --filter unleash-${UNLEASH_VERSION} build
 
-# Deploy target version with production dependencies only
-# Using --legacy for pnpm v10+ compatibility
-RUN pnpm deploy --filter=unleash-${UNLEASH_VERSION} --prod --legacy /prod/unleash
+# Deploy the target and its injected workspace dependencies as a standalone app.
+RUN pnpm deploy --filter=unleash-${UNLEASH_VERSION} --prod /prod/unleash
+
+# Fail if the package escapes the deploy root or cannot load with production deps.
+RUN cd /prod/unleash && \
+    node -e "const fs = require('node:fs'); const root = process.cwd() + '/'; const dependency = fs.realpathSync('node_modules/@nais/unleash-shared'); if (!dependency.startsWith(root)) throw new Error('@nais/unleash-shared points outside the deploy root'); require('@nais/unleash-shared')"
 
 # Production Stage
 # Using Node.js 24 distroless for minimal attack surface

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "4.0.0",
   "description": "NAIS customized Unleash feature flag server - monorepo",
   "private": true,
+  "packageManager": "pnpm@11.20.0",
   "scripts": {
     "db:start": "docker compose up -d postgres && echo 'Waiting for PostgreSQL...' && until docker compose exec -T postgres pg_isready -U unleash > /dev/null 2>&1; do sleep 1; done && echo 'Database ready!'",
     "db:stop": "docker compose down",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -4,6 +4,9 @@
   "description": "Shared authentication and authorization modules for NAIS Unleash",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,6 +3,7 @@ lockfileVersion: '9.0'
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
+  injectWorkspacePackages: true
 
 overrides:
   axios: '>=1.15.2'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,11 @@
 packages:
   - packages/*
 
+injectWorkspacePackages: true
+
+syncInjectedDepsAfterScripts:
+  - build
+
 ignoredBuiltDependencies:
   - core-js
 


### PR DESCRIPTION
## Incident

Release images for both Unleash v6 and v7 failed at startup with:

```text
Error: Cannot find module '@nais/unleash-shared'
```

The PR workflow and release workflow used different pnpm versions. Release builds resolved the floating `pnpm@latest` to pnpm 11.20.0, where the legacy workspace deployment could leave `@nais/unleash-shared` linked outside the standalone production deployment. CI only started PR-built images; images rebuilt and published from `main` were not exercised before publication.

## Changes

- pin pnpm 11.20.0 in the Dockerfile, workflows and `packageManager`
- replace `pnpm deploy --legacy` with supported injected workspace packages
- include the shared package's built `dist` files in its published file set
- fail the Docker build unless `@nais/unleash-shared` resolves inside the deployment root and loads with production dependencies only
- run Docker E2E for v6 and v7 on both pull requests and pushes to `main`
- make image publication depend on those Docker E2E jobs

## Validation

Both v6 and v7 production images are built and started in CI. The E2E jobs verify:

- application startup and `/health`
- Prometheus endpoint
- authenticated admin API access
- production resolution of `@nais/unleash-shared`

## Follow-up

- #344 tracks ReleaseChannel rollback/configuration hardening
- nais/unleasherator#779 tracks rollout advancement before instance readiness
- nais/unleasherator#753 and nais/unleasherator#754 track related batching bypasses