### PR TITLE
fix(tsconfig): drop baseUrl and use relative path targets

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,11 +40,13 @@
     // "noUncheckedIndexedAccess": true,      /* Include 'undefined' in index signature results */
     /* Module Resolution Options */
     // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    "baseUrl": "." /* Base directory to resolve non-absolute module names. */,
+    /* baseUrl was removed in TypeScript 7 (TS5102) and path targets must be
+       relative (TS5090). Without baseUrl, paths resolve relative to this
+       config file, which behaves identically on TypeScript 5.x. */
     "paths": {
-      "@nais/unleash-shared": ["packages/shared/src/index.ts"],
-      "@nais/unleash-shared/*": ["packages/shared/src/*"]
-    } /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */,
+      "@nais/unleash-shared": ["./packages/shared/src/index.ts"],
+      "@nais/unleash-shared/*": ["./packages/shared/src/*"]
+    } /* A series of entries which re-map imports to lookup locations relative to this config file. */,
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */


### PR DESCRIPTION
## Problem

TypeScript 7 removes `baseUrl` and rejects non-relative entries in `paths`. The root `tsconfig.json` uses both, so `packages/shared` fails to build the moment TypeScript 7 is installed:

```
tsconfig.json(3,3): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
tsconfig.json(3,3): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
```

That is one of the two things blocking #342.

## Change

Drop `baseUrl` and prefix the path targets with `./`. Without `baseUrl`, path targets resolve relative to the config file, so this is equivalent on TypeScript 5.x — a no-op today that removes the blocker for whenever TS 7 becomes reachable.

## The other blocker is upstream, and this PR does not fix it

`typescript-eslint` has no TypeScript 7 support. Its latest release, **8.67.0**, still declares:

```
peerDependencies: typescript >=4.8.4 <6.1.0
```

The `canary` tag (8.67.1-alpha.4) carries the same constraint. So `Error: typescript-eslint does not support TS 7.0` in #342 cannot be resolved by picking a different version — there is no version to pick.

**#342 stays unmergeable until typescript-eslint ships TS 7 support**, and rebasing it will not help. If the other 12 updates in that group are wanted sooner, the practical option is a dependabot `ignore` on `typescript` major 7 in the `npm-root` ecosystem, so the group can be regenerated without the impossible bump. That is a policy call and is deliberately left out of this PR.

## Verification

On the pinned TypeScript 5.9.3:
- `pnpm -r build` — all three packages clean
- `pnpm -r lint` — clean
- `packages/shared` tests — 3 files, 11 tests, all pass

`packages/unleash-v6` tests fail locally with `Required environment variable DATABASE_HOST is not set`; that is identical on a clean `main` and comes from the local env, not this change.
