### PR TITLE
chore(dependabot): block the TypeScript 7 major until eslint supports it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,8 +35,16 @@ updates:
       timezone: "Europe/Oslo"
     # Note: @types/node major version must match Node.js major version
     # Do not update to @types/node@25 until distroless supports nodejs25
+    #
+    # Note: typescript-eslint has no TypeScript 7 support — its latest release
+    # (8.67.0) still declares `typescript >=4.8.4 <6.1.0`, and lint fails hard
+    # with "typescript-eslint does not support TS 7.0". Blocking the major
+    # keeps the rest of the group mergeable. Remove this once typescript-eslint
+    # ships TS 7 support.
     ignore:
       - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
     groups:
       npm-root:


### PR DESCRIPTION
## Why

`typescript-eslint` has **no TypeScript 7 support in any release**. Its latest, 8.67.0, still declares:

```
peerDependencies: typescript >=4.8.4 <6.1.0
```

The `canary` tag (8.67.1-alpha.4) carries the same constraint. So the failure in #342 —

```
packages/shared lint: Error: typescript-eslint does not support TS 7.0.
```

— cannot be fixed by choosing a different version. There is no version to choose.

That makes #342 unmergeable no matter how often dependabot rebases it, and it takes the **other twelve updates in the npm-root group** down with it. #332 (vite) is blocked the same way.

## Change

Add a `version-update:semver-major` ignore for `typescript` in the npm-root ecosystem, mirroring the `@types/node` entry already there and with the reason in a comment.

Dependabot will regenerate the group without the impossible bump, so the remaining updates can land.

## When to remove

Delete the entry once typescript-eslint ships TS 7 support. The other half of the migration — `tsconfig.json` still using `baseUrl` and non-relative `paths`, both removed in TS 7 — is handled in #347, which can land independently and is a no-op on TypeScript 5.x.

## Verification

`.github/dependabot.yml` parses, and the npm-root entry resolves to:

```json
[
  { "dependency-name": "@types/node", "update-types": ["version-update:semver-major"] },
  { "dependency-name": "typescript",  "update-types": ["version-update:semver-major"] }
]
```
